### PR TITLE
Feature/#94 feedback entity

### DIFF
--- a/ii-infrastructure/build.gradle
+++ b/ii-infrastructure/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/ii-infrastructure/src/main/java/com/ureca/entity/Enum/LikeStatus.java
+++ b/ii-infrastructure/src/main/java/com/ureca/entity/Enum/LikeStatus.java
@@ -1,0 +1,27 @@
+package com.ureca.entity.Enum;
+
+public enum LikeStatus {
+  DISLIKE(-1),
+  CANCELED(0),
+  LIKE(1);
+
+  private int value;
+
+  LikeStatus(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public static LikeStatus fromValue(int value) {
+    for (LikeStatus status : LikeStatus.values()) {
+      if (status.getValue() == value) {
+        return status;
+      }
+    }
+    throw new IllegalArgumentException("유효하지 않는 숫자 : " + value);
+  }
+
+}

--- a/ii-infrastructure/src/main/java/com/ureca/entity/Enum/LikeStatusConverter.java
+++ b/ii-infrastructure/src/main/java/com/ureca/entity/Enum/LikeStatusConverter.java
@@ -1,0 +1,18 @@
+package com.ureca.entity.Enum;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class LikeStatusConverter implements AttributeConverter<LikeStatus, Integer> {
+
+  @Override
+  public Integer convertToDatabaseColumn(LikeStatus status) {
+    return status != null ? status.getValue() : null;
+  }
+
+  @Override
+  public LikeStatus convertToEntityAttribute(Integer value) {
+    return value != null ? LikeStatus.fromValue(value) : null;
+  }
+}

--- a/ii-infrastructure/src/main/java/com/ureca/entity/FeedbackLogEntity.java
+++ b/ii-infrastructure/src/main/java/com/ureca/entity/FeedbackLogEntity.java
@@ -1,0 +1,55 @@
+package com.ureca.entity;
+
+import com.ureca.entity.Enum.LikeStatus;
+import com.ureca.entity.Enum.LikeStatusConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "feedback_log")
+@Getter
+@NoArgsConstructor
+public class FeedbackLogEntity {
+
+  @Id
+  @Column(name = "logId")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer logId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "childId")
+  private ChildEntity childEntity;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "bookId")
+  private BookEntity bookEntity;
+
+  @Column(name = "isLike", nullable = false)
+  @Convert(converter = LikeStatusConverter.class)
+  private LikeStatus isLike;
+
+  @UpdateTimestamp
+  @Column(name = "timeStamp", nullable = false)
+  private LocalDateTime timeStamp;
+
+  @Builder
+  public FeedbackLogEntity(ChildEntity childEntity, BookEntity bookEntity, LikeStatus isLike) {
+    this.childEntity = childEntity;
+    this.bookEntity = bookEntity;
+    this.isLike = isLike;
+  }
+
+}

--- a/ii-infrastructure/src/main/java/com/ureca/entity/FeedbackStatusEntity.java
+++ b/ii-infrastructure/src/main/java/com/ureca/entity/FeedbackStatusEntity.java
@@ -1,0 +1,55 @@
+package com.ureca.entity;
+
+import com.ureca.entity.Enum.LikeStatus;
+import com.ureca.entity.Enum.LikeStatusConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "feedback_status")
+@Getter
+@NoArgsConstructor
+public class FeedbackStatusEntity {
+
+  @Id
+  @Column(name = "feedbackId")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long feedbackId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "childId")
+  private ChildEntity childEntity;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "bookId")
+  private BookEntity bookEntity;
+
+  @Column(name = "isLike", nullable = false)
+  @Convert(converter = LikeStatusConverter.class)
+  private LikeStatus isLike;
+
+  @UpdateTimestamp
+  @Column(name = "updateAt", nullable = false)
+  private LocalDateTime updateAt;
+
+  @Builder
+  public FeedbackStatusEntity(ChildEntity childEntity, BookEntity bookEntity, LikeStatus isLike) {
+    this.childEntity = childEntity;
+    this.bookEntity = bookEntity;
+    this.isLike = isLike;
+  }
+
+}

--- a/ii-infrastructure/src/main/java/com/ureca/entity/MbtiHistoryEntity.java
+++ b/ii-infrastructure/src/main/java/com/ureca/entity/MbtiHistoryEntity.java
@@ -1,0 +1,74 @@
+package com.ureca.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "mbti_history")
+@Getter
+@NoArgsConstructor
+public class MbtiHistoryEntity {
+
+  @Id
+  @Column(name = "historyId")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long historyId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "childId")
+  private ChildEntity childEntity;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "logId")
+  private FeedbackLogEntity feedbackLogEntity;
+
+  @Column(name = "typeIE", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typeIE;
+
+  @Column(name = "typeSN", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typeSN;
+
+  @Column(name = "typeTF", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typeTF;
+
+  @Column(name = "typePJ", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typePJ;
+
+  @UpdateTimestamp
+  @Column(name = "timeStamp", nullable = false)
+  private LocalDateTime timeStamp;
+
+  @Builder
+  public MbtiHistoryEntity(ChildEntity childEntity, FeedbackLogEntity feedbackLogEntity
+        , Integer typeIE, Integer typeSN, Integer typeTF, Integer typePJ) {
+      this.childEntity = childEntity;
+      this.feedbackLogEntity = feedbackLogEntity;
+      this.typeIE = typeIE;
+      this.typeSN = typeSN;
+      this.typeTF = typeTF;
+      this.typePJ = typePJ;
+  }
+}

--- a/ii-infrastructure/src/main/java/com/ureca/entity/MbtiStatusEntity.java
+++ b/ii-infrastructure/src/main/java/com/ureca/entity/MbtiStatusEntity.java
@@ -1,0 +1,69 @@
+package com.ureca.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "mbti_status")
+@Getter
+@NoArgsConstructor
+public class MbtiStatusEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "typeId")
+  private Long typeId;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "childId")
+  private ChildEntity childEntity;
+
+  @Column(name = "typeIE", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typeIE;
+
+  @Column(name = "typeSN", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typeSN;
+
+  @Column(name = "typeTF", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typeTF;
+
+  @Column(name = "typePJ", nullable = false)
+  @Min(1)
+  @Max(10)
+  private Integer typePJ;
+
+  @UpdateTimestamp
+  @Column(name = "updateAt", nullable = false)
+  private LocalDateTime updateAt;
+
+  @Builder
+  public MbtiStatusEntity(ChildEntity childEntity, Integer typeIE, Integer typeSN, Integer typeTF,
+      Integer typePJ) {
+    this.childEntity = childEntity;
+    this.typeIE = typeIE;
+    this.typeSN = typeSN;
+    this.typeTF = typeTF;
+    this.typePJ = typePJ;
+  }
+
+}

--- a/ii-infrastructure/src/main/java/com/ureca/repository/FeedbackLogRepository.java
+++ b/ii-infrastructure/src/main/java/com/ureca/repository/FeedbackLogRepository.java
@@ -1,0 +1,8 @@
+package com.ureca.repository;
+
+import com.ureca.entity.FeedbackLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackLogRepository extends JpaRepository<FeedbackLogEntity, Long> {
+
+}

--- a/ii-infrastructure/src/main/java/com/ureca/repository/FeedbackStatusRepository.java
+++ b/ii-infrastructure/src/main/java/com/ureca/repository/FeedbackStatusRepository.java
@@ -1,0 +1,8 @@
+package com.ureca.repository;
+
+import com.ureca.entity.FeedbackStatusEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackStatusRepository extends JpaRepository<FeedbackStatusEntity, Long> {
+
+}

--- a/ii-infrastructure/src/main/java/com/ureca/repository/MbtiHistoryRepository.java
+++ b/ii-infrastructure/src/main/java/com/ureca/repository/MbtiHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.ureca.repository;
+
+import com.ureca.entity.MbtiHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MbtiHistoryRepository extends JpaRepository<MbtiHistoryEntity, Long> {
+
+}

--- a/ii-infrastructure/src/main/java/com/ureca/repository/MbtiStatusRepository.java
+++ b/ii-infrastructure/src/main/java/com/ureca/repository/MbtiStatusRepository.java
@@ -1,0 +1,8 @@
+package com.ureca.repository;
+
+import com.ureca.entity.MbtiStatusEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MbtiStatusRepository extends JpaRepository<MbtiStatusEntity, Long> {
+
+}

--- a/ii-infrastructure/src/test/java/ureca/entity/FeedbackLogTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/FeedbackLogTest.java
@@ -1,0 +1,65 @@
+package ureca.entity;
+
+import com.ureca.MainApplication;
+import com.ureca.entity.Enum.LikeStatus;
+import com.ureca.entity.FeedbackLogEntity;
+import com.ureca.repository.FeedbackLogRepository;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = MainApplication.class)
+public class FeedbackLogTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(FeedbackLogTest.class);
+
+  @Autowired
+  FeedbackLogRepository feedbackLogRepository;
+
+  @Test
+  public void insertFeetback() throws Exception {
+    FeedbackLogEntity newFeetbackLike = FeedbackLogEntity.builder()
+        .childEntity(null)
+        .bookEntity(null)
+        .isLike(LikeStatus.LIKE) // 1 : 좋아요
+        .build();
+
+    FeedbackLogEntity savedFeedback = feedbackLogRepository.save(newFeetbackLike);
+    logger.info(savedFeedback.toString());
+
+    FeedbackLogEntity newFeetbackDisLike = FeedbackLogEntity.builder()
+        .childEntity(null)
+        .bookEntity(null)
+        .isLike(LikeStatus.DISLIKE) // -1 : 싫어요
+        .build();
+
+    savedFeedback = feedbackLogRepository.save(newFeetbackDisLike);
+    logger.info(savedFeedback.toString());
+
+    FeedbackLogEntity newFeetbackCanceled = FeedbackLogEntity.builder()
+        .childEntity(null)
+        .bookEntity(null)
+        .isLike(LikeStatus.CANCELED) // 0 : 취소(반응 없음)
+        .build();
+
+    savedFeedback = feedbackLogRepository.save(newFeetbackCanceled);
+    logger.info(savedFeedback.toString());
+
+    try {
+      FeedbackLogEntity newFeetbackByNum = FeedbackLogEntity.builder()
+          .childEntity(null)
+          .bookEntity(null)
+          .isLike(LikeStatus.fromValue(2)) // -1 ~ 1 외의 값
+          .build();
+
+      savedFeedback = feedbackLogRepository.save(newFeetbackByNum);
+      logger.info(savedFeedback.toString());
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+
+  }
+}

--- a/ii-infrastructure/src/test/java/ureca/entity/FeedbackLogTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/FeedbackLogTest.java
@@ -4,12 +4,14 @@ import com.ureca.MainApplication;
 import com.ureca.entity.Enum.LikeStatus;
 import com.ureca.entity.FeedbackLogEntity;
 import com.ureca.repository.FeedbackLogRepository;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Transactional
 @SpringBootTest(classes = MainApplication.class)
 public class FeedbackLogTest {
 

--- a/ii-infrastructure/src/test/java/ureca/entity/FeedbackLogTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/FeedbackLogTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @Transactional
-@SpringBootTest(classes = MainApplication.class)
+@SpringBootTest
 public class FeedbackLogTest {
 
   private static final Logger logger = LoggerFactory.getLogger(FeedbackLogTest.class);

--- a/ii-infrastructure/src/test/java/ureca/entity/FeetbackStatusTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/FeetbackStatusTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @Transactional
-@SpringBootTest(classes = MainApplication.class)
+@SpringBootTest
 public class FeetbackStatusTest {
 
   private static final Logger logger = LoggerFactory.getLogger(FeetbackStatusTest.class);

--- a/ii-infrastructure/src/test/java/ureca/entity/FeetbackStatusTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/FeetbackStatusTest.java
@@ -1,0 +1,66 @@
+package ureca.entity;
+
+import com.ureca.MainApplication;
+import com.ureca.entity.Enum.LikeStatus;
+import com.ureca.entity.FeedbackStatusEntity;
+import com.ureca.repository.FeedbackStatusRepository;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = MainApplication.class)
+public class FeetbackStatusTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(FeetbackStatusTest.class);
+
+  @Autowired
+  FeedbackStatusRepository feedbackStatusRepository;
+
+  @Test
+  public void insertFeetback() throws Exception {
+    FeedbackStatusEntity newFeetbackLike = FeedbackStatusEntity.builder()
+        .childEntity(null)
+        .bookEntity(null)
+        .isLike(LikeStatus.LIKE) // 1 : 좋아요
+        .build();
+
+    FeedbackStatusEntity savedFeedback = feedbackStatusRepository.save(newFeetbackLike);
+    logger.info(savedFeedback.toString());
+
+    FeedbackStatusEntity newFeetbackDisLike = FeedbackStatusEntity.builder()
+        .childEntity(null)
+        .bookEntity(null)
+        .isLike(LikeStatus.DISLIKE) // -1 : 싫어요
+        .build();
+
+    savedFeedback = feedbackStatusRepository.save(newFeetbackDisLike);
+    logger.info(savedFeedback.toString());
+
+    FeedbackStatusEntity newFeetbackCanceled = FeedbackStatusEntity.builder()
+        .childEntity(null)
+        .bookEntity(null)
+        .isLike(LikeStatus.CANCELED) // 0 : 취소(반응 없음)
+        .build();
+
+    savedFeedback = feedbackStatusRepository.save(newFeetbackCanceled);
+    logger.info(savedFeedback.toString());
+
+    try {
+      FeedbackStatusEntity newFeetbackByNum = FeedbackStatusEntity.builder()
+          .childEntity(null)
+          .bookEntity(null)
+          .isLike(LikeStatus.fromValue(2)) // -1 ~ 1 외의 값
+          .build();
+
+      savedFeedback = feedbackStatusRepository.save(newFeetbackByNum);
+      logger.info(savedFeedback.toString());
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+
+  }
+
+}

--- a/ii-infrastructure/src/test/java/ureca/entity/FeetbackStatusTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/FeetbackStatusTest.java
@@ -4,12 +4,14 @@ import com.ureca.MainApplication;
 import com.ureca.entity.Enum.LikeStatus;
 import com.ureca.entity.FeedbackStatusEntity;
 import com.ureca.repository.FeedbackStatusRepository;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Transactional
 @SpringBootTest(classes = MainApplication.class)
 public class FeetbackStatusTest {
 

--- a/ii-infrastructure/src/test/java/ureca/entity/MbtiHistoryTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/MbtiHistoryTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @Transactional
-@SpringBootTest(classes = MainApplication.class)
+@SpringBootTest
 public class MbtiHistoryTest {
 
   private static final Logger logger = LoggerFactory.getLogger(FeetbackStatusTest.class);

--- a/ii-infrastructure/src/test/java/ureca/entity/MbtiHistoryTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/MbtiHistoryTest.java
@@ -3,12 +3,14 @@ package ureca.entity;
 import com.ureca.MainApplication;
 import com.ureca.entity.MbtiHistoryEntity;
 import com.ureca.repository.MbtiHistoryRepository;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Transactional
 @SpringBootTest(classes = MainApplication.class)
 public class MbtiHistoryTest {
 

--- a/ii-infrastructure/src/test/java/ureca/entity/MbtiHistoryTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/MbtiHistoryTest.java
@@ -1,0 +1,37 @@
+package ureca.entity;
+
+import com.ureca.MainApplication;
+import com.ureca.entity.MbtiHistoryEntity;
+import com.ureca.repository.MbtiHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = MainApplication.class)
+public class MbtiHistoryTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(FeetbackStatusTest.class);
+
+  @Autowired
+  MbtiHistoryRepository mbtiHistoryRepository;
+
+  @Test
+  public void insertMbti() {
+    for (int i = 0; i < 30; i++) {
+      MbtiHistoryEntity newMbtiStatus = MbtiHistoryEntity.builder()
+          .childEntity(null)
+          .feedbackLogEntity(null)
+          .typeIE(1)
+          .typeSN(10)
+          .typeTF(1)
+          .typePJ(10)
+          .build();
+
+      MbtiHistoryEntity savedMbtiStatus = mbtiHistoryRepository.save(newMbtiStatus);
+      logger.info(savedMbtiStatus.toString());
+    }
+  }
+
+}

--- a/ii-infrastructure/src/test/java/ureca/entity/MbtiStatusTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/MbtiStatusTest.java
@@ -3,12 +3,14 @@ package ureca.entity;
 import com.ureca.MainApplication;
 import com.ureca.entity.MbtiStatusEntity;
 import com.ureca.repository.MbtiStatusRepository;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Transactional
 @SpringBootTest(classes = MainApplication.class)
 public class MbtiStatusTest {
 

--- a/ii-infrastructure/src/test/java/ureca/entity/MbtiStatusTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/MbtiStatusTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @Transactional
-@SpringBootTest(classes = MainApplication.class)
+@SpringBootTest
 public class MbtiStatusTest {
 
   private static final Logger logger = LoggerFactory.getLogger(FeetbackStatusTest.class);

--- a/ii-infrastructure/src/test/java/ureca/entity/MbtiStatusTest.java
+++ b/ii-infrastructure/src/test/java/ureca/entity/MbtiStatusTest.java
@@ -1,0 +1,38 @@
+package ureca.entity;
+
+import com.ureca.MainApplication;
+import com.ureca.entity.MbtiStatusEntity;
+import com.ureca.repository.MbtiStatusRepository;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = MainApplication.class)
+public class MbtiStatusTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(FeetbackStatusTest.class);
+
+  @Autowired
+  MbtiStatusRepository mbtiStatusRepository;
+
+  @Test
+  public void insertMbti() {
+    for (int i = 0; i < 30; i++) {
+      MbtiStatusEntity newMbtiStatus = MbtiStatusEntity.builder()
+          .childEntity(null)
+          .typeIE(1)
+          .typeSN(10)
+          .typeTF(3)
+          .typePJ(8)
+          .build();
+
+      MbtiStatusEntity savedMbtiStatus = mbtiStatusRepository.save(newMbtiStatus);
+      logger.info(savedMbtiStatus.toString());
+    }
+
+
+  }
+
+}


### PR DESCRIPTION
# ✏️ PR 요약
- 성향 상태, 히스토리 앤티티 생성
- 피드백 상태, 로그 엔티티 생성

# 📌 주요 변경 사항
- 좋아요 상태는 싫어요, 상태없음(취소), 좋아요로 구분 각각 -1, 0, 1의 값으로 고정
- Mbti 각각 반대되는 성향끼리 묶어 1이상 10이하의 값을 가지도록 고정
- 각 엔티티는 생성, 수정될시 자동으로 시간 업데이트

# ⭐ 관련 이슈
Resolve #94